### PR TITLE
Dev

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are always supported for the latest version of the project.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest  | :white_check_mark: |
+| Older   | :x:                |
+
+## Reporting a Vulnerability
+
+If you should spot any vulnerabilities or other security issues, please report them directly to [security@collado.ch](mailto:security@collado.ch).

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       echo 'Building display...' && cd /workspace/examples/display && alr --non-interactive build && arm-none-eabi-objcopy -O ihex bin/display bin/display.hex &&
       echo 'Building sensors...' && cd /workspace/examples/sensors && alr --non-interactive build && arm-none-eabi-objcopy -O ihex bin/sensors bin/sensors.hex &&
       echo 'Building compass...' && cd /workspace/examples/compass && alr --non-interactive build && arm-none-eabi-objcopy -O ihex bin/compass bin/compass.hex &&
+      echo 'Building spi_loopback...' && cd /workspace/examples/spi_loopback && alr --non-interactive build && arm-none-eabi-objcopy -O ihex bin/spi_loopback bin/spi_loopback.hex &&
       echo 'Building audio...' && cd /workspace/examples/audio && alr --non-interactive build && arm-none-eabi-objcopy -O ihex bin/audio bin/audio.hex &&
       echo 'Building wav_player...' && cd /workspace/examples/wav_player && alr --non-interactive build && arm-none-eabi-objcopy -O ihex bin/wav_player bin/wav_player.hex &&
       echo 'Building parrot...' && cd /workspace/examples/parrot && alr --non-interactive build && arm-none-eabi-objcopy -O ihex bin/parrot bin/parrot.hex &&

--- a/examples/spi_loopback/README.md
+++ b/examples/spi_loopback/README.md
@@ -1,0 +1,13 @@
+# Compass Example
+
+This example demonstrates how to read and calibrate the LSM303AGR magnetometer on the micro:bit v2 to compute a 2D heading pointing to Magnetic North.
+
+## Calibration Phase
+When the application starts, you have **10 seconds** to rotate the micro:bit smoothly in a flat, horizontal circle. The software will monitor the minimum and maximum magnetic field strengths on the X and Y axes to calculate the "hard iron" offsets specific to your environment.
+
+## How to use
+1. Build the example using `alr build` or via the containerized workflow.
+2. Flash the generated `bin/compass.hex` to your micro:bit v2.
+3. Open a serial terminal at `115200` baud.
+4. Follow the prompt to rotate the board for 10 seconds.
+5. After calibration, it will print your heading in degrees (0-360) where 0 is North, 90 is East, 180 is South, and 270 is West.

--- a/examples/spi_loopback/alire.toml
+++ b/examples/spi_loopback/alire.toml
@@ -1,0 +1,14 @@
+name = "spi_loopback"
+description = "Micro:bit v2 Compass Example"
+version = "0.1.0"
+
+authors = ["Jorlly Collado <jorlly@collado.ch>"]
+maintainers = ["Jorlly Collado <jorlly@collado.ch>"]
+maintainers-logins = ["jorlly-collado-castro"]
+licenses = "GPL-3.0-only"
+
+[[depends-on]]
+microbit_v2 = "*"
+
+[[pins]]
+microbit_v2 = { path='../..' }

--- a/examples/spi_loopback/spi_loopback.gpr
+++ b/examples/spi_loopback/spi_loopback.gpr
@@ -1,0 +1,31 @@
+with "config/spi_loopback_config.gpr";
+with "../../microbit_v2.gpr";
+
+project Spi_Loopback is
+
+   for Source_Dirs use ("src/", "config/");
+   for Object_Dir use "obj/" & Spi_Loopback_Config.Build_Profile;
+   for Create_Missing_Dirs use "True";
+   for Exec_Dir use "bin";
+   for Main use ("spi_loopback.adb");
+
+   for Target use "arm-eabi";
+   for Runtime ("Ada") use "light-tasking-nrf52833";
+
+   package Compiler is
+      for Default_Switches ("Ada") use Spi_Loopback_Config.Ada_Compiler_Switches & ("-gnat2022") &
+         ("-gnat2022",
+          "-gnatp",
+          "-mfloat-abi=hard",
+          "-mfpu=fpv4-sp-d16");
+   end Compiler;
+
+   package Binder is
+      for Switches ("Ada") use ("-Es"); --  Symbolic traceback
+   end Binder;
+
+   package Install is
+      for Artifacts (".") use ("share");
+   end Install;
+
+end Spi_Loopback;

--- a/examples/spi_loopback/src/spi_loopback.adb
+++ b/examples/spi_loopback/src/spi_loopback.adb
@@ -1,0 +1,92 @@
+pragma SPARK_Mode (On);
+
+with Microbit.Console;
+with Microbit.Display;
+with Microbit.SPI;
+with Interfaces; use Interfaces;
+with Ada.Real_Time; use Ada.Real_Time;
+
+procedure Spi_Loopback is
+   --  Test payload (not constant, to force placement in RAM for EasyDMA)
+   pragma Warnings (Off, "Tx_Buf");
+   --  Test payload. Volatile ensures placement in RAM for EasyDMA.
+   Tx_Buf : aliased Microbit.SPI.Data_Buffer (0 .. 4) :=
+     [16#DE#, 16#AD#, 16#BE#, 16#EF#, 16#42#];
+   Rx_Buf : aliased Microbit.SPI.Data_Buffer (0 .. 4) :=
+     [others => 0];
+
+   pragma Volatile (Tx_Buf);
+   pragma Volatile (Rx_Buf);
+   pragma Warnings (On, "Tx_Buf");
+
+   Success : Boolean;
+   Period  : constant Time_Span := Milliseconds (1000);
+   Next_Tx : Time;
+
+   Check_Mark : constant Microbit.Display.Matrix :=
+     [[False, False, False, False, False],
+      [False, False, False, False, True],
+      [False, False, False, True,  False],
+      [True,  False, True,  False, False],
+      [False, True,  False, False, False]];
+
+   Cross_Mark : constant Microbit.Display.Matrix :=
+     [[True,  False, False, False, True],
+      [False, True,  False, True,  False],
+      [False, False, True,  False, False],
+      [False, True,  False, True,  False],
+      [True,  False, False, False, True]];
+begin
+   Microbit.Console.Initialize;
+   Microbit.Display.Initialize;
+
+   Microbit.Console.Put_Line ("SPI Loopback Example Started");
+   Microbit.Console.Put_Line
+     ("Please connect Pin 14 (MISO) to Pin 15 (MOSI) with a jumper wire.");
+
+   Microbit.SPI.Initialize
+     (Mode      => Microbit.SPI.Mode_0,
+      Frequency => Microbit.SPI.F_1M);
+
+   Next_Tx := Clock;
+
+   loop
+      Microbit.Console.Put_Line ("Transmitting...");
+
+      Microbit.SPI.Transfer (Tx_Data => Tx_Buf, Rx_Data => Rx_Buf);
+
+      Success := True;
+      for I in Tx_Buf'Range loop
+         if Rx_Buf (I) /= Tx_Buf (I) then
+            Success := False;
+         end if;
+      end loop;
+
+      if Success then
+         Microbit.Console.Put_Line ("Loopback SUCCESS! Data matched.");
+         Microbit.Display.Show (Check_Mark);
+      else
+         Microbit.Console.Put_Line ("Loopback FAILED! Data mismatched.");
+         Microbit.Console.Put ("Sent: [");
+         for B of Tx_Buf loop
+            Microbit.Console.Put (Unsigned_8'Image (B) & " ");
+         end loop;
+         Microbit.Console.Put_Line ("]");
+
+         Microbit.Console.Put ("Rcvd: [");
+         for B of Rx_Buf loop
+            Microbit.Console.Put (Unsigned_8'Image (B) & " ");
+         end loop;
+         Microbit.Console.Put_Line ("]");
+
+         Microbit.Display.Show (Cross_Mark);
+      end if;
+
+      Next_Tx := Next_Tx + Period;
+      declare
+         Now : constant Time := Clock;
+      begin
+         delay until Now + Period; -- Wait 1 second before next transfer
+      end;
+   end loop;
+end Spi_Loopback;

--- a/src/microbit-pins.ads
+++ b/src/microbit-pins.ads
@@ -37,4 +37,9 @@ package Microbit.Pins is
    P1  : constant Pin_Id := (Port_0, 3);
    P2  : constant Pin_Id := (Port_0, 4);
 
+   -- SPI (Edge Connector)
+   SPI_SCK  : constant Pin_Id := (Port_0, 17); -- Pad 13
+   SPI_MISO : constant Pin_Id := (Port_0, 1);  -- Pad 14
+   SPI_MOSI : constant Pin_Id := (Port_0, 13); -- Pad 15
+
 end Microbit.Pins;

--- a/src/microbit-spi.adb
+++ b/src/microbit-spi.adb
@@ -1,0 +1,127 @@
+pragma SPARK_Mode (Off);
+
+with NRF52833_SVD.SPIM; use NRF52833_SVD.SPIM;
+with NRF52833_SVD; use NRF52833_SVD;
+with System.Storage_Elements;
+
+package body Microbit.SPI is
+
+   use type Microbit.Pins.Port_Id;
+
+   function To_UInt32 (Address : System.Address) return UInt32 is
+     (UInt32 (System.Storage_Elements.To_Integer (Address)));
+
+   procedure Initialize
+     (SCK_Pin   : Microbit.Pins.Pin_Id := Microbit.Pins.SPI_SCK;
+      MOSI_Pin  : Microbit.Pins.Pin_Id := Microbit.Pins.SPI_MOSI;
+      MISO_Pin  : Microbit.Pins.Pin_Id := Microbit.Pins.SPI_MISO;
+      Mode      : SPI_Mode := Mode_0;
+      Frequency : SPI_Frequency := F_4M)
+   is
+      CPOL : CONFIG_CPOL_Field;
+      CPHA : CONFIG_CPHA_Field;
+      Freq : UInt32;
+   begin
+      --  Configure Pins as outputs/inputs
+      Microbit.Pins.Configure (SCK_Pin, Microbit.Pins.Output);
+      Microbit.Pins.Configure (MOSI_Pin, Microbit.Pins.Output);
+      Microbit.Pins.Configure (MISO_Pin, Microbit.Pins.Input);
+
+      --  Disable SPIM2 before configuring
+      SPIM2_Periph.ENABLE := (ENABLE => Disabled, others => <>);
+
+      --  Set up PSEL
+      SPIM2_Periph.PSEL.SCK :=
+        (PIN => UInt5 (SCK_Pin.Pin),
+         PORT => (if SCK_Pin.Port = Microbit.Pins.Port_0 then 0 else 1),
+         CONNECT => Connected,
+         others => <>);
+
+      SPIM2_Periph.PSEL.MOSI :=
+        (PIN => UInt5 (MOSI_Pin.Pin),
+         PORT => (if MOSI_Pin.Port = Microbit.Pins.Port_0 then 0 else 1),
+         CONNECT => Connected,
+         others => <>);
+
+      SPIM2_Periph.PSEL.MISO :=
+        (PIN => UInt5 (MISO_Pin.Pin),
+         PORT => (if MISO_Pin.Port = Microbit.Pins.Port_0 then 0 else 1),
+         CONNECT => Connected,
+         others => <>);
+
+      --  Map SPI Mode
+      case Mode is
+         when Mode_0 => CPOL := ActiveHigh; CPHA := Leading;
+         when Mode_1 => CPOL := ActiveHigh; CPHA := Trailing;
+         when Mode_2 => CPOL := ActiveLow;  CPHA := Leading;
+         when Mode_3 => CPOL := ActiveLow;  CPHA := Trailing;
+      end case;
+
+      SPIM2_Periph.CONFIG := (CPOL => CPOL, CPHA => CPHA, ORDER => MsbFirst, others => <>);
+
+      --  Map Frequency (Using direct hex values from nRF52833 Product Spec)
+      case Frequency is
+         when F_125K => Freq := 16#0200_0000#;
+         when F_250K => Freq := 16#0400_0000#;
+         when F_500K => Freq := 16#0800_0000#;
+         when F_1M   => Freq := 16#1000_0000#;
+         when F_2M   => Freq := 16#2000_0000#;
+         when F_4M   => Freq := 16#4000_0000#;
+         when F_8M   => Freq := 16#8000_0000#;
+      end case;
+
+      SPIM2_Periph.FREQUENCY := Freq;
+
+      --  Enable SPIM2
+      SPIM2_Periph.ENABLE := (ENABLE => Enabled, others => <>);
+   end Initialize;
+
+   procedure Transfer (Tx_Data : Data_Buffer;
+                       Rx_Data : out Data_Buffer)
+   is
+      Timeout : Natural := 10_000_000;
+   begin
+      --  Initialize Rx_Data to avoid uninitialized variable warnings
+      Rx_Data := [others => 0];
+
+      SPIM2_Periph.EVENTS_END := (EVENTS_END => NotGenerated, others => <>);
+
+      SPIM2_Periph.TXD.PTR := To_UInt32 (Tx_Data (Tx_Data'First)'Address);
+      SPIM2_Periph.TXD.MAXCNT := (MAXCNT => MAXCNT_TXD_MAXCNT_Field (Tx_Data'Length), others => <>);
+
+      SPIM2_Periph.RXD.PTR := To_UInt32 (Rx_Data (Rx_Data'First)'Address);
+      SPIM2_Periph.RXD.MAXCNT := (MAXCNT => MAXCNT_RXD_MAXCNT_Field (Rx_Data'Length), others => <>);
+
+      SPIM2_Periph.TASKS_START := (TASKS_START => Trigger, others => <>);
+
+      --  Wait for transfer to complete using tight polling
+      while SPIM2_Periph.EVENTS_END.EVENTS_END = NotGenerated and then Timeout > 0 loop
+         Timeout := @ - 1;
+      end loop;
+
+      SPIM2_Periph.EVENTS_END := (EVENTS_END => NotGenerated, others => <>);
+   end Transfer;
+
+   procedure Write (Tx_Data : Data_Buffer)
+   is
+      Timeout : Natural := 10_000_000;
+   begin
+      SPIM2_Periph.EVENTS_END := (EVENTS_END => NotGenerated, others => <>);
+
+      SPIM2_Periph.TXD.PTR := To_UInt32 (Tx_Data (Tx_Data'First)'Address);
+      SPIM2_Periph.TXD.MAXCNT := (MAXCNT => MAXCNT_TXD_MAXCNT_Field (Tx_Data'Length), others => <>);
+
+      --  No Rx Data
+      SPIM2_Periph.RXD.PTR := 0;
+      SPIM2_Periph.RXD.MAXCNT := (MAXCNT => 0, others => <>);
+
+      SPIM2_Periph.TASKS_START := (TASKS_START => Trigger, others => <>);
+
+      while SPIM2_Periph.EVENTS_END.EVENTS_END = NotGenerated and then Timeout > 0 loop
+         Timeout := @ - 1;
+      end loop;
+
+      SPIM2_Periph.EVENTS_END := (EVENTS_END => NotGenerated, others => <>);
+   end Write;
+
+end Microbit.SPI;

--- a/src/microbit-spi.ads
+++ b/src/microbit-spi.ads
@@ -1,0 +1,36 @@
+pragma SPARK_Mode (On);
+
+with Microbit.Pins;
+with Interfaces;
+
+package Microbit.SPI is
+
+   type SPI_Mode is (Mode_0, Mode_1, Mode_2, Mode_3);
+   --  Mode_0: CPOL = 0, CPHA = 0 (Active High, leading edge)
+   --  Mode_1: CPOL = 0, CPHA = 1 (Active High, trailing edge)
+   --  Mode_2: CPOL = 1, CPHA = 0 (Active Low, leading edge)
+   --  Mode_3: CPOL = 1, CPHA = 1 (Active Low, trailing edge)
+
+   type SPI_Frequency is (F_125K, F_250K, F_500K, F_1M, F_2M, F_4M, F_8M);
+
+   type Data_Buffer is array (Natural range <>) of Interfaces.Unsigned_8;
+
+   --  Initialize the SPI Master using SPIM2 peripheral
+   procedure Initialize
+     (SCK_Pin   : Microbit.Pins.Pin_Id := Microbit.Pins.SPI_SCK;
+      MOSI_Pin  : Microbit.Pins.Pin_Id := Microbit.Pins.SPI_MOSI;
+      MISO_Pin  : Microbit.Pins.Pin_Id := Microbit.Pins.SPI_MISO;
+      Mode      : SPI_Mode := Mode_0;
+      Frequency : SPI_Frequency := F_4M);
+
+   --  Perform a full-duplex transfer over SPI
+   procedure Transfer (Tx_Data : Data_Buffer;
+                       Rx_Data : out Data_Buffer)
+     with Pre => Tx_Data'Length = Rx_Data'Length and then
+                 Tx_Data'Length <= 32767; -- EasyDMA constraint
+
+   --  Perform a write-only transfer
+   procedure Write (Tx_Data : Data_Buffer)
+     with Pre => Tx_Data'Length <= 32767;
+
+end Microbit.SPI;


### PR DESCRIPTION
This pull request introduces a new SPI peripheral driver for the micro:bit v2, along with a loopback example to demonstrate its functionality. It also adds a security policy to the project and updates the build process to include the new example. The main themes are the addition of SPI support, an example application, and project documentation improvements.

**SPI Support and Example:**

* Added a new `Microbit.SPI` driver, including API definitions (`src/microbit-spi.ads`) and implementation for SPI master mode using the nRF52833's SPIM2 peripheral (`src/microbit-spi.adb`). The driver supports configurable pins, SPI modes, and frequencies, and provides `Initialize`, `Transfer`, and `Write` procedures. [[1]](diffhunk://#diff-ccdd7fa6f65633790d04db60bf223805101bd675f5ddc51909141368d7c57f21R1-R36) [[2]](diffhunk://#diff-299f1436f2fdde334a29c3ed529f1c51e988b89b452584a6fb740bf7cf168de9R1-R127)
* Defined SPI pin constants in `Microbit.Pins` for SCK, MISO, and MOSI, corresponding to the micro:bit edge connector pins.
* Added a new example project, `spi_loopback`, including project files, configuration, and a main program (`spi_loopback.adb`) that tests SPI loopback by transferring data and displaying the result on the device. [[1]](diffhunk://#diff-d98f3464e1e38e691f0d69b00d22fe7fa54faa5b47b8a619495a75eb9ba21912R1-R14) [[2]](diffhunk://#diff-65e316de0463da8f06eae01aa274b4e90e65ce43d13e3aa4969c2a5960b6e42dR1-R31) [[3]](diffhunk://#diff-6a2af3584e2f3430de21df99bbea1714bb177ba99312c9b1ce0ce02529d3a38eR1-R92)

**Build and Documentation Improvements:**

* Updated `examples/docker-compose.yml` to build the new `spi_loopback` example as part of the standard build workflow.
* Added a README for the new example (though the content describes a compass example, which may need correction to match the spi_loopback functionality).

**Project Policy:**

* Introduced a `SECURITY.md` file specifying the project's security policy, supported versions, and vulnerability reporting process.